### PR TITLE
Bind OS_KEY+\\ to Fold All in Sublime Text and VS Code

### DIFF
--- a/docs/editor-keybindings.md
+++ b/docs/editor-keybindings.md
@@ -156,12 +156,12 @@ Brave keyboard shortcuts settings: `brave://settings/system/shortcuts`
 | `OS_KEY+]` | Indent         |   ✅    |    ✅     |     ❌     | ❌  | ❌  |
 | `OS_KEY+,` | Fold           |   ✅    |    ✅     |     ❌     | ❌  | ❌  |
 | `OS_KEY+.` | Unfold         |   ✅    |    ✅     |     ❌     | ❌  | ❌  |
+| `OS_KEY+\` | Fold all       |   ✅    |    ✅     |     ❌     | ❌  | ❌  |
 
 ### Editor UI
 
 | Key                   | Action               | VS Code | Subl Text | Subl Merge | Zed | Vim |
 | --------------------- | -------------------- | :-----: | :-------: | :--------: | :-: | :-: |
-| `OS_KEY+\`            | Toggle sidebar       |   ✅    |    ✅     |     ❌     | ❌  | ❌  |
 | `OS_KEY+shift+\`      | Toggle activity bar  |   ✅    |    ❌     |     ❌     | ❌  | ❌  |
 | `ctrl+shift+OS_KEY+\` | Toggle right sidebar |   ✅    |    ❌     |     ❌     | ❌  | ❌  |
 | `` OS_KEY+` ``        | Toggle terminal      |   ✅    |    ❌     |     ❌     | ❌  | ❌  |

--- a/software/scripts/advanced/sublime-text-keys.common.jsonc
+++ b/software/scripts/advanced/sublime-text-keys.common.jsonc
@@ -44,9 +44,10 @@
     "key": "OS_KEY+o",
     "command": "prompt_open_file",
   },
+  // fold all / collapse all (replaces toggle_side_bar — sidebar is still available via View menu)
   {
     "key": "OS_KEY+\\",
-    "command": "toggle_side_bar",
+    "command": "fold_all",
   },
   {
     "key": "OS_KEY+enter",

--- a/software/scripts/advanced/vs-code-keys.common.jsonc
+++ b/software/scripts/advanced/vs-code-keys.common.jsonc
@@ -19,9 +19,11 @@
   { "key": "f5", "command": "workbench.action.files.revert" },
   { "key": "OS_KEY+h", "command": "editor.action.startFindReplaceAction", "when": "editorFocus || editorIsOpen" },
   { "key": "OS_KEY+h", "command": "testing.toggleTestingPeekHistory", "when": "testing.isPeekVisible" },
+  // fold all / collapse all (replaces toggleSidebarVisibility — sidebar is still available via View menu)
   {
     "key": "OS_KEY+\\",
-    "command": "workbench.action.toggleSidebarVisibility",
+    "command": "editor.foldAll",
+    "when": "editorTextFocus",
   },
   {
     "key": "OS_KEY+shift+\\",


### PR DESCRIPTION
## Summary
- Repoint \`OS_KEY+\\\` (cmd+\\\ on macOS / alt+\\\ on Windows & Linux) from the sidebar toggle to \`fold_all\` (Sublime) / \`editor.foldAll\` (VS Code), so the same chord collapses all folds across both editors.
- Sidebar toggle remains reachable via the View menu.
- Updated \`docs/editor-keybindings.md\` to reflect the change.

## Test plan
- [x] \`make validate\` passes
- [ ] Reload Sublime Text after setup and confirm \`cmd+\\\` / \`alt+\\\` collapses all folds
- [ ] Reload VS Code after setup and confirm \`cmd+\\\` / \`alt+\\\` folds all