### PR TITLE
Add synle/skiff-files installer (mirrors display-dj/sqlui-native)

### DIFF
--- a/software/metadata/script-list.config
+++ b/software/metadata/script-list.config
@@ -51,6 +51,7 @@ software/scripts/advanced/ollama.sh
 software/scripts/advanced/opencode.sh
 software/scripts/advanced/remmina-config.js
 software/scripts/advanced/remote-connections.js
+software/scripts/advanced/skiff-files.js
 software/scripts/advanced/sqlui-native.js
 software/scripts/advanced/ssh.js
 software/scripts/advanced/starship-config.js

--- a/software/scripts/advanced/skiff-files.js
+++ b/software/scripts/advanced/skiff-files.js
@@ -1,0 +1,19 @@
+/** Installs the synle/skiff-files desktop app from its GitHub release feed. */
+
+/** @type {string} GitHub repo identifier for skiff-files releases. */
+const SKIFF_FILES_REPO = "synle/skiff-files";
+
+/**
+ * Downloads the skiff-files application binary for the current platform.
+ * No post-install permission reset is needed — skiff-files does not require
+ * macOS Accessibility / input-event grants.
+ */
+async function doWork() {
+  await downloadAndInstallBinary(SKIFF_FILES_REPO, (ver, isArm64) => {
+    return is_os_mac
+      ? `Skiff.Files_${ver}_${isArm64 ? "aarch64" : "x64"}.dmg`
+      : is_os_windows
+        ? `Skiff.Files_${ver}_x64-setup.exe`
+        : `Skiff.Files_${ver}_amd64.AppImage`;
+  });
+}

--- a/software/scripts/mac/_only.js
+++ b/software/scripts/mac/_only.js
@@ -14,6 +14,7 @@ async function doWork() {
     alias sqluinative='open "/Applications/sqlui-native.app" --args --disable-smooth-scrolling'
     alias sql="sqluinative"
     alias displaydj='open "/Applications/Display DJ.app"'
+    alias skiff='open "/Applications/Skiff Files.app"'
 
     # make: use GNU Make (gmake) for .ONESHELL support (macOS ships Make 3.81)
     if type -P gmake &> /dev/null; then alias make='gmake'; fi
@@ -26,6 +27,7 @@ async function doWork() {
       _xattr_app_list=(
         "/Applications/sqlui-native.app"
         "/Applications/Display DJ.app"
+        "/Applications/Skiff Files.app"
       )
       _xattr_app=""
       for _xattr_app in "\${_xattr_app_list[@]}"; do

--- a/software/tools/ci-download-release-binaries.sh
+++ b/software/tools/ci-download-release-binaries.sh
@@ -223,6 +223,7 @@ VEOF
     "synle/url-porter"
     "synle/sqlui-native"
     "synle/display-dj"
+    "synle/skiff-files"
   )
 
   for repo_id in "${RELEASE_REPOS[@]}"; do


### PR DESCRIPTION
## Summary
- New `software/scripts/advanced/skiff-files.js` installs the synle/skiff-files desktop app from its GitHub release feed (Mac `.dmg`, Windows `setup.exe`, Linux `.AppImage`). No tccutil/Accessibility step — skiff-files is just a file explorer.
- CI release-asset backup: appended `synle/skiff-files` to `RELEASE_REPOS` in `software/tools/ci-download-release-binaries.sh` so the assets are mirrored under `assets/binaries/` by the prep step.
- Mac `mac/_only.js`: new `skiff` alias and `/Applications/Skiff Files.app` entry in `_xattr_app_list` (Gatekeeper quarantine clear).
- `software/metadata/script-list.config` regenerated by `make format`.

## Test plan
- [x] `make validate` (format + unit tests) — green locally
- [ ] CI Prep step picks up the new RELEASE_REPOS entry and mirrors release assets
- [ ] Per-OS CI builds discover advanced/skiff-files.js (full setup pass)
- [ ] Profile syntax checks still pass with the new Mac _only.js entries

Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>