### PR TITLE
fix(ci): retry gh release view + distinguish 404 from auth/transient

### DIFF
--- a/software/tools/ci-download-release-binaries.sh
+++ b/software/tools/ci-download-release-binaries.sh
@@ -116,11 +116,37 @@
   # exists but is in draft state — draft assets are private (404 to anonymous
   # curl), which defeats the entire downloadAssetWithFallback() / installer
   # one-liner story. Idempotent: subsequent calls are a no-op on a healthy release.
+  #
+  # Retries `gh release view` up to 3 times on transient API/auth failures.
+  # Why: GitHub-hosted runners occasionally see one-off 5xx or "no auth"
+  # responses for a valid token, and the prior code swallowed any non-zero
+  # exit via `> /dev/null 2>&1`, then fell through to the "first-time setup"
+  # branch — which crashed with HTTP 401 when `gh release create` ran against
+  # an already-existing release. The fix: only fall through to create when we
+  # see a literal "release not found" body (genuine 404); any other failure is
+  # retried with backoff and surfaced loudly if it survives all attempts.
   function ensure_cache_release() {
-    if gh release view "$CACHE_TAG" --repo "$CACHE_REPO" > /dev/null 2>&1; then
-      local is_draft
-      is_draft=$(gh release view "$CACHE_TAG" --repo "$CACHE_REPO" --json isDraft --jq .isDraft 2> /dev/null || echo "false")
-      if [ "$is_draft" = "true" ]; then
+    local view_output view_rc attempt
+    for attempt in 1 2 3; do
+      view_rc=0
+      view_output=$(gh release view "$CACHE_TAG" --repo "$CACHE_REPO" --json isDraft --jq .isDraft 2>&1) || view_rc=$?
+      if [ "$view_rc" -eq 0 ]; then
+        break
+      fi
+      # 404 from the API surfaces as "release not found" in gh CLI output.
+      # Anything else (401, 5xx, network blips) gets retried.
+      if echo "$view_output" | grep -qi "release not found"; then
+        view_rc=404
+        break
+      fi
+      if [ "$attempt" -lt 3 ]; then
+        echo "::warning::gh release view $CACHE_TAG attempt $attempt/3 failed (rc=$view_rc): $view_output"
+        sleep $((attempt * 2))
+      fi
+    done
+
+    if [ "$view_rc" -eq 0 ]; then
+      if [ "$view_output" = "true" ]; then
         echo ">> $CACHE_REPO release $CACHE_TAG is in draft state — publishing for anonymous access"
         if ! gh release edit "$CACHE_TAG" --repo "$CACHE_REPO" --draft=false > /dev/null 2>&1; then
           echo "::warning::Failed to publish draft release $CACHE_TAG — assets will remain private (404 to anonymous curl)"
@@ -128,6 +154,12 @@
       fi
       return 0
     fi
+
+    if [ "$view_rc" != "404" ]; then
+      echo "::error::gh release view $CACHE_TAG --repo $CACHE_REPO failed 3x (rc=$view_rc); last error: $view_output"
+      return 1
+    fi
+
     echo ">> Creating $CACHE_REPO release $CACHE_TAG (first-time setup)"
     gh release create "$CACHE_TAG" \
       --repo "$CACHE_REPO" \


### PR DESCRIPTION
## Summary
- `ensure_cache_release` swallowed every non-zero exit from `gh release view` behind `> /dev/null 2>&1` and treated the failure as "release doesn't exist".
- A one-off 401/5xx from the GitHub API (observed twice on `ubuntu-24.04` runners today on commits `a840b98` and `7ba3b8d`) flipped the script into the "first-time setup" branch, where `gh release create` then crashed with `HTTP 401: Requires authentication (https://api.github.com/repos/synle/bashrc/releases)` against the already-existing `binary-cache` release — failing the entire CI Prep step.
- Manual rerun of the same SHA went green, confirming the failure was transient. This PR makes the script resilient to that class of blip.

## Changes
- Retry `gh release view` up to 3 times with `2s, 4s` backoff.
- Only fall through to `gh release create` when the body is literally `release not found` (genuine 404).
- Anything else (auth, 5xx, network) is surfaced via `::error::` and returns `1` instead of corrupting the next `gh` call.

## Test plan
Local stubbed harness against `synle/bashrc`'s real `binary-cache` release:
- [x] Happy path — release exists → returns 0 silently.
- [x] 404 path — nonexistent tag → falls through to "create".
- [x] No-auth path — 3 retries then `::error::` and non-zero return.
- [x] `make validate` (format + unit tests) passes in worktree.

## Notes
- Failed runs: [27289644810](https://github.com/synle/bashrc/actions/runs/27289644810) (`7ba3b8d`), [27287344623](https://github.com/synle/bashrc/actions/runs/27287344623) (`a840b98`). Manual rerun of `27289644810` after the API blip cleared went fully green, which is what motivates the retry approach rather than re-plumbing auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)